### PR TITLE
Use `actions.select_default` instead of deprecated function

### DIFF
--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -65,7 +65,7 @@ local plugins = function(opts)
     },
     sorter = sorters.get_generic_fuzzy_sorter(),
     attach_mappings = function(prompt_bufnr)
-      actions.goto_file_selection_edit:replace(function()
+      actions.select_default:replace(function()
         local selection = actions.get_selected_entry(prompt_bufnr)
         actions.close(prompt_bufnr)
 


### PR DESCRIPTION
Fixes #2 