### PR TITLE
ENTER to read selected pack doc

### DIFF
--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -68,7 +68,7 @@ local plugins = function(opts)
       actions.select_default:replace(function()
         local selection = actions.get_selected_entry(prompt_bufnr)
         actions.close(prompt_bufnr)
-
+		vim.cmd(string.format(":e %s", selection.readme))
         -- packer[selection.value]()
       end)
 


### PR DESCRIPTION
When selecting a package, nothing happens.
Ideally I think it would be better to open the github repo but I don't know how to do it.
Meanwhile, I've made it open the readme files.