### PR TITLE
fix: null of `opt.theme`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ require("telescope").load_extension "packer"
 ## Available functions
 
 ```lua
-require('telescope').extensions.packer.plugins(opts)
+require('telescope').extensions.packer.packer(opts)
 ```
 
 ## Available mappings

--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -23,7 +23,7 @@ end
 local user_opts
 local setup = function(opts)
   opts = opts or {}
-  if opts.theme ~= "" then
+  if opts.theme and opts.theme ~= "" then
     user_opts = themes["get_" .. opts.theme](opts)
   else
     user_opts = opts


### PR DESCRIPTION
1. Allow use default layout of `telescope` without passing extension settings to telescope setup
2. Update doc