### PR TITLE
Trim \n from the end of repo URL

### DIFF
--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -90,9 +90,7 @@ local plugins = function(opts)
         actions._close(prompt_bufnr)
 
         local cmd = vim.fn.has "win-32" == 1 and "start" or vim.fn.has "mac" == 1 and "open" or "xdg-open"
-        local url = vim.fn.system(string.format("git -C %s ls-remote --get-url", selection.path))
- 		-- Trim newline character at the end of the URL
-        url = string.gsub(url, "\n", "")
+        local url = vim.fn.trim(vim.fn.system(string.format("git -C %s ls-remote --get-url", selection.path)))
         Job:new({command = cmd, args = {url}}):start()
       end
 

--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -91,6 +91,8 @@ local plugins = function(opts)
 
         local cmd = vim.fn.has "win-32" == 1 and "start" or vim.fn.has "mac" == 1 and "open" or "xdg-open"
         local url = vim.fn.system(string.format("git -C %s ls-remote --get-url", selection.path))
+ 				-- Trim newline character at the end of the URL
+        url = string.gsub(url, "\n", "")
         Job:new({command = cmd, args = {url}}):start()
       end
 

--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -91,7 +91,7 @@ local plugins = function(opts)
 
         local cmd = vim.fn.has "win-32" == 1 and "start" or vim.fn.has "mac" == 1 and "open" or "xdg-open"
         local url = vim.fn.system(string.format("git -C %s ls-remote --get-url", selection.path))
- 				-- Trim newline character at the end of the URL
+ 		-- Trim newline character at the end of the URL
         url = string.gsub(url, "\n", "")
         Job:new({command = cmd, args = {url}}):start()
       end


### PR DESCRIPTION
Fixes the newline character that breaks the open repo command. The git command appends `\n` to the URL, which breaks the "open" command on MacOS