### PR TITLE
fix: use telescope extension file_browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Integration for [packer.nvim](https://github.com/wbthomason/packer.nvim) with [t
 
 - [packer.nvim](https://github.com/wbthomason/packer.nvim) (required)
 - [telescope.nvim](https://github.com/nvim-telescope/telescope.nvim) (required)
+- [telescope-file-browser.nvim](https://github.com/nvim-telescope/telescope-file-browser.nvim) (optional, only for `file_browser` action)
 
 ## Available commands
 

--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -105,7 +105,9 @@ local plugins = function(opts)
       local open_browser = function()
         local selection = action_state.get_selected_entry()
         actions._close(prompt_bufnr, true)
-        builtin.file_browser({cwd = selection.path})
+        local file_browser = require("telescope").extensions.file_browser
+        if not file_browser then return end
+        file_browser.file_browser({cwd = selection.path})
       end
 
       local open_grep = function()

--- a/lua/telescope/_extensions/packer.lua
+++ b/lua/telescope/_extensions/packer.lua
@@ -106,7 +106,10 @@ local plugins = function(opts)
         local selection = action_state.get_selected_entry()
         actions._close(prompt_bufnr, true)
         local file_browser = require("telescope").extensions.file_browser
-        if not file_browser then return end
+        if not file_browser then
+          vim.notify("telescope-file-browser is required to use this action", vim.log.levels.WARN, { title = "Telescope" })
+          return
+        end
         file_browser.file_browser({cwd = selection.path})
       end
 


### PR DESCRIPTION
`file_brower` has been seperated from `telescope.nvim` and become a extension of it.
https://github.com/nvim-telescope/telescope-file-browser.nvim